### PR TITLE
docs: update xbbg main dependency comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,20 @@ Same result. One line.
 
 ### vs. xbbg
 
-xbbg is a capable library, but its v1 rewrite introduced a Rust core, `narwhals`, and `pyarrow>=22` as hard dependencies — over 30MB of transitive installs for what most quant teams use: `bdp`, `bdh`, and `bds`.
+xbbg is a capable library, but its v1 rewrite introduced a Rust core plus `narwhals` and `pyarrow>=22`, so a fresh install is heavier than bbg-fetch. The size comparison should be like-for-like: wheel size versus wheel size, and full transitive install versus full transitive install.
 
 | | **bbg-fetch** | **xbbg v1** |
 |---|---|---|
-| Dependencies | `numpy` + `pandas` | `narwhals` + `pyarrow` + Rust binary |
-| Install size | ~50KB (plus blpapi) | ~30MB+ transitive |
+| Dependencies | `numpy` + `pandas` | `narwhals` + `pyarrow` + Rust extension |
+| Wheel size | 22KB (`bbg-fetch==2.0.0`) | ~1.9–2.2MB (`xbbg==1.1.2`, platform wheel) |
+| Fresh install size | ~74MB including pandas/numpy | ~89MB including pyarrow/narwhals |
 | Python support | 3.9–3.12 | 3.10–3.14 |
 | Intraday bars / streaming | No | Yes |
 | Exchange-aware market hours | No | Yes |
 | Session management | Automatic singleton | Configurable pool |
 | Debug Bloomberg errors | Your code, 400 lines | Third-party internals |
+
+Fresh install sizes above are clean `uv pip install --target` measurements and exclude `blpapi`. xbbg's Rust core is used for performance and for sharing one Bloomberg engine across Python, JavaScript, and MCP/server surfaces; bbg-fetch remains the smaller path when you only need BDP/BDH/BDS-style workflows.
 
 **bbg-fetch is for teams that need historical, reference, and bulk data — reliably, with minimal dependencies.** If you need intraday bars or real-time streaming, use xbbg.
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ xbbg is a capable library, but its v1 rewrite introduced a Rust core plus `narwh
 |---|---|---|
 | Dependencies | `numpy` + `pandas` | `narwhals` + `pyarrow` + Rust extension |
 | Wheel size | 22KB (`bbg-fetch==2.0.0`) | ~1.9–2.2MB (`xbbg==1.1.2`, platform wheel) |
-| Fresh install size | ~74MB including pandas/numpy | ~89MB including pyarrow/narwhals |
+| Fresh install size | ~74 MiB including pandas/numpy | ~89 MiB including pyarrow/narwhals |
 | Python support | 3.9–3.12 | 3.10–3.14 |
 | Intraday bars / streaming | No | Yes |
 | Exchange-aware market hours | No | Yes |
 | Session management | Automatic singleton | Configurable pool |
 | Debug Bloomberg errors | Your code, 400 lines | Third-party internals |
 
-Fresh install sizes above are clean `uv pip install --target` measurements and exclude `blpapi`. xbbg's Rust core is used for performance and for sharing one Bloomberg engine across Python, JavaScript, and MCP/server surfaces; bbg-fetch remains the smaller path when you only need BDP/BDH/BDS-style workflows.
+Fresh install sizes above are clean `uv pip install --target` measurements on Windows 11 AMD64 with CPython 3.12.13, excluding `blpapi`, using current resolver output at measurement time. They vary by platform and dependency versions: native wheels such as `pyarrow`, `numpy`, and `pandas` can materially change totals.
 
 **bbg-fetch is for teams that need historical, reference, and bulk data — reliably, with minimal dependencies.** If you need intraday bars or real-time streaming, use xbbg.
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ xbbg is a capable library, but its v1 rewrite introduced a Rust core plus `narwh
 |---|---|---|
 | Dependencies | `numpy` + `pandas` | `narwhals` + `pyarrow` + Rust extension |
 | Wheel size | 22KB (`bbg-fetch==2.0.0`) | ~1.9–2.2MB (`xbbg==1.1.2`, platform wheel) |
-| Fresh install size | ~74 MiB including pandas/numpy | ~89 MiB including pyarrow/narwhals |
-| Python support | 3.9–3.12 | 3.10–3.14 |
+| Fresh install size | ~74–92 MiB including pandas/numpy | ~89–156 MiB including pyarrow/narwhals |
+| Python support | 3.9–3.12 | 3.10+ |
 | Intraday bars / streaming | No | Yes |
 | Exchange-aware market hours | No | Yes |
 | Session management | Automatic singleton | Configurable pool |
 | Debug Bloomberg errors | Your code, 400 lines | Third-party internals |
 
-Fresh install sizes above are clean `uv pip install --target` measurements on Windows 11 AMD64 with CPython 3.12.13, excluding `blpapi`, using current resolver output at measurement time. They vary by platform and dependency versions: native wheels such as `pyarrow`, `numpy`, and `pandas` can materially change totals.
+Fresh-install ranges are clean CPython 3.12 `uv pip install --target` measurements across Windows x64, Linux x86_64, and macOS x64/arm64, excluding `blpapi`; exact totals vary with platform and resolver output.
 
 **bbg-fetch is for teams that need historical, reference, and bulk data — reliably, with minimal dependencies.** If you need intraday bars or real-time streaming, use xbbg.
 

--- a/README.md
+++ b/README.md
@@ -67,26 +67,27 @@ Same result. One line.
 
 ### vs. xbbg
 
-xbbg is a capable library, but its v1 rewrite introduced a Rust core plus `narwhals` and `pyarrow>=22`, so a fresh install is heavier than bbg-fetch. The size comparison should be like-for-like: wheel size versus wheel size, and full transitive install versus full transitive install.
+xbbg is a capable, feature-rich Bloomberg stack. For the latest `main` branch, local measurements show a significantly smaller default install footprint and fewer default Python dependencies than `bbg-fetch`: the default runtime dependency is `narwhals>=2.0`, with `pyarrow` available as an optional extra. The comparison below uses like-for-like local measurements for `bbg-fetch` and an xbbg wheel built from current `main`.
 
-| | **bbg-fetch** | **xbbg v1** |
+| | **bbg-fetch 2.0.0** | **xbbg main wheel** |
 |---|---|---|
-| Dependencies | `numpy` + `pandas` | `narwhals` + `pyarrow` + Rust extension |
-| Wheel size | 22KB (`bbg-fetch==2.0.0`) | ~1.9–2.2MB (`xbbg==1.1.2`, platform wheel) |
-| Fresh install size | ~74–92 MiB including pandas/numpy | ~89–156 MiB including pyarrow/narwhals |
-| Python support | 3.9–3.12 | 3.10+ |
+| Default Python dependencies | `numpy` + `pandas` | `narwhals` (`pyarrow` is optional) |
+| Native code | No package-native extension | Rust extension |
+| Wheel size | 22KB | 1.90 MiB (`cp314-win_amd64`, built from `alpha-xone/xbbg@ad0cf7c`) |
+| Fresh install size | 73.9 MiB on Windows x64 / CPython 3.12; cross-platform range ~74–92 MiB | 8.0 MiB on Windows x64 / CPython 3.14 from the locally built main wheel |
+| Python support | 3.9–3.12 | 3.10–3.14 |
 | Intraday bars / streaming | No | Yes |
 | Exchange-aware market hours | No | Yes |
 | Session management | Automatic singleton | Configurable pool |
 | Debug Bloomberg errors | Your code, 400 lines | Third-party internals |
 
-Fresh-install ranges are clean CPython 3.12 `uv pip install --target` measurements across Windows x64, Linux x86_64, and macOS x64/arm64, excluding `blpapi`; exact totals vary with platform and resolver output.
+Fresh-install numbers are clean `uv pip install --target` measurements excluding `blpapi`. The xbbg wheel measurement uses a locally built `cp314-win_amd64` wheel from `alpha-xone/xbbg@ad0cf7c`; exact totals will vary by platform, Python tag, and final release build.
 
-**bbg-fetch is for teams that need historical, reference, and bulk data — reliably, with minimal dependencies.** If you need intraday bars or real-time streaming, use xbbg.
+**bbg-fetch is for teams that need historical, reference, and bulk data through a small direct Bloomberg wrapper.** If you need intraday bars or real-time streaming, use xbbg.
 
 ### The sweet spot
 
-bbg-fetch sits between raw blpapi (too low-level) and xbbg (too many dependencies). It wraps the three Bloomberg services that cover 95% of quant workflows — BDP, BDH, BDS — into high-level functions that return clean DataFrames with proper column naming, corporate action adjustments, and index alignment.
+bbg-fetch sits between raw blpapi (too low-level) and feature-rich Bloomberg stacks such as xbbg. It wraps the three Bloomberg services that cover 95% of many quant workflows — BDP, BDH, BDS — into high-level functions that return clean DataFrames with proper column naming, corporate action adjustments, and index alignment.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,21 +67,22 @@ Same result. One line.
 
 ### vs. xbbg
 
-xbbg is a capable, feature-rich Bloomberg stack. For the latest `main` branch, local measurements show a significantly smaller default install footprint and fewer default Python dependencies than `bbg-fetch`: the default runtime dependency is `narwhals>=2.0`, with `pyarrow` available as an optional extra. The comparison below uses like-for-like local measurements for `bbg-fetch` and an xbbg wheel built from current `main`.
+xbbg is a capable, feature-rich Bloomberg stack. With the published `xbbg==1.2.0` release, the default install is now much smaller than `bbg-fetch` in like-for-like local measurements: xbbg's only default runtime dependency is `narwhals>=2.0`, while `pyarrow` is optional. The comparison below uses PyPI wheels measured on the same Windows x64 / CPython 3.12 target.
 
-| | **bbg-fetch 2.0.0** | **xbbg main wheel** |
+| | **bbg-fetch 2.0.0** | **xbbg 1.2.0** |
 |---|---|---|
 | Default Python dependencies | `numpy` + `pandas` | `narwhals` (`pyarrow` is optional) |
 | Native code | No package-native extension | Rust extension |
-| Wheel size | 22KB | 1.90 MiB (`cp314-win_amd64`, built from `alpha-xone/xbbg@ad0cf7c`) |
-| Fresh install size | 73.9 MiB on Windows x64 / CPython 3.12; cross-platform range ~74–92 MiB | 8.0 MiB on Windows x64 / CPython 3.14 from the locally built main wheel |
-| Python support | 3.9–3.12 | 3.10–3.14 |
+| Wheel size | 0.021 MiB (`bbg_fetch-2.0.0-py3-none-any.whl`) | 2.029 MiB (`xbbg-1.2.0-cp312-cp312-win_amd64.whl`) |
+| Fresh install size | 73.929 MiB | 8.391 MiB |
+| Largest installed entries | `pandas` 33.019 MiB; `numpy` + `numpy.libs` 38.839 MiB | `xbbg` 6.450 MiB; `narwhals` 1.800 MiB |
+| Python support | 3.9+ | 3.10–3.14 |
 | Intraday bars / streaming | No | Yes |
 | Exchange-aware market hours | No | Yes |
 | Session management | Automatic singleton | Configurable pool |
 | Debug Bloomberg errors | Your code, 400 lines | Third-party internals |
 
-Fresh-install numbers are clean `uv pip install --target` measurements excluding `blpapi`. The xbbg wheel measurement uses a locally built `cp314-win_amd64` wheel from `alpha-xone/xbbg@ad0cf7c`; exact totals will vary by platform, Python tag, and final release build.
+Fresh-install numbers are clean `uv pip install --target` measurements with `--python-version 3.12`, `--python-platform x86_64-pc-windows-msvc`, and `--only-binary :all:`, excluding `blpapi` for both packages. The xbbg measurement cites the published [`xbbg==1.2.0`](https://github.com/alpha-xone/xbbg/releases/tag/v1.2.0) / PyPI release rather than a locally built main-branch wheel. Exact totals will vary by platform and dependency resolver date; this run resolved `bbg-fetch` to `pandas==3.0.2` / `numpy==2.4.4` and xbbg to `narwhals==2.20.0`.
 
 **bbg-fetch is for teams that need historical, reference, and bulk data through a small direct Bloomberg wrapper.** If you need intraday bars or real-time streaming, use xbbg.
 


### PR DESCRIPTION
## Summary

Closes #1.

This updates the README xbbg comparison using the published `xbbg==1.2.0` release instead of a locally built xbbg main wheel:

- presents xbbg 1.2.0 as having a smaller default install footprint than `bbg-fetch` in like-for-like local measurements
- notes that xbbg 1.2.0's default Python runtime dependency is `narwhals>=2.0`, with `pyarrow` available as an optional extra
- reports published PyPI wheel sizes and clean install sizes for both packages on the same Windows x64 / CPython 3.12 target
- keeps the comparison like-for-like: wheel size vs wheel size, and clean `uv pip install --target` install size vs install size
- keeps the wording factual and release-specific rather than relying on main-branch measurements

## Measurements / evidence

Clean local measurements excluding `blpapi`, using:

```bash
uv pip install --target <target> --python-version 3.12 --python-platform x86_64-pc-windows-msvc --only-binary :all: <package>
```

Results:

- `bbg-fetch==2.0.0`: 0.021 MiB wheel (`bbg_fetch-2.0.0-py3-none-any.whl`); 73.929 MiB fresh install on Windows x64 / CPython 3.12 (`pandas` 33.019 MiB, `numpy` + `numpy.libs` 38.839 MiB, `bbg_fetch` 0.048 MiB)
- `xbbg==1.2.0`: 2.029 MiB wheel (`xbbg-1.2.0-cp312-cp312-win_amd64.whl`); 8.391 MiB fresh install on Windows x64 / CPython 3.12 (`xbbg` 6.450 MiB, `narwhals` 1.800 MiB)

Release cited: https://github.com/alpha-xone/xbbg/releases/tag/v1.2.0

I also checked xbbg 1.2.0 metadata: default dependency is `narwhals>=2.0`; `pyarrow>=22.0.0` is optional under the `pyarrow` extra.

## Validation

- verified `xbbg==1.2.0` is published on PyPI via `uvx --from pip pip index versions xbbg`
- verified `@xbbg/core` and the platform npm packages are published at `1.2.0`
- measured both Python package installs with `uv pip install --target` and `--only-binary :all:`
- `git diff --check`
